### PR TITLE
add H option

### DIFF
--- a/main.go
+++ b/main.go
@@ -49,6 +49,7 @@ type Configure struct {
 	FilePath          string   `short:"f" default:"" description:"Input file path"`
 	FileDir           string   `short:"b" default:"" description:"Attachment file directory"`
 	DeleteAll         bool     `short:"D" description:"Delete records before insert. You can specify the deleting record condition by option \"-q\""`
+	CheckHeader       bool     `short:"H" long:"check-header" description:"Check CSV Header exists in kintone fileds"`
 	Line              uint64   `short:"l" default:"1" description:"Position index of data in the input file"`
 	Version           bool     `short:"v" long:"version" description:"Version of cli-kintone"`
 }


### PR DESCRIPTION
Add H option for check CSV header for importing.
When I used cli-kintone for import some data. Command successly ended, but some columns left blank.
I mistaked column names in CSV header. I must fix Header and retry import.
I want option for checking CSV header, and implement this.
